### PR TITLE
[Broken Link Fix]: Issue Template link fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ python3 scripts/run_benchmarks.py \
 We welcome contributions from the community! Here's how you can help:
 
 ### **🐛 Bug Reports**
-- Use our [issue template](https://github.com/your-org/eka-eval/issues/new?template=bug_report.md)
+- Use our [issue template](https://github.com/lingo-iitgn/eka-eval/issues/new?template=bug_report.md)
 - Include error logs, model names, and reproduction steps
 - Test with minimal examples when possible
 


### PR DESCRIPTION
Hi,
Inside the readme under [🐛Bug Reports] section, the GitHub issue link for the bug-report template was incomplete.
Changed `https://github.com/your-org/eka-eval/issues/new?template=bug_report.md`
 to 
`https://github.com/lingo-iitgn/eka-eval/issues/new?template=bug_report.md`

 @sam22ridhi,
